### PR TITLE
Explicitly define default port

### DIFF
--- a/src/LCBUrl.cpp
+++ b/src/LCBUrl.cpp
@@ -41,7 +41,7 @@ LCBUrl::LCBUrl() {
     username = "";
     password = "";
     host = "";
-    port = -1;
+    port = 65535;
     authority = "";
     pathsegment = "";
     path = "";


### PR DESCRIPTION
Currently, you're implicitly setting port = 65535 by setting an `unsigned int` to -1. The problem though is that you aren't actually using an `unsigned int` as the type definition for `getPort` - you're using a `word` which is a processor-specific definition, and thus this behavior is different on an ESP32, for example. 

This pull request just sets the default port to 65535 at initialization of the object, which is in line with the behavior of what `getPort` expects