### PR TITLE
Valid hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ If you are using mDNS in your projects, you may have discovered many microcontro
 - getAfterPath() = ?foo=bar#frag
 - getQuery() = foo=bar
 - getFragment() = frag
-- isMDNS() = Boolean
 
 :exclamation: IMPORTANT: Using any of the IP-based methods in a timer will crash or hang your program. This hang is not a shortcoming of this library; it is how radio-functions (networking being one) work.
 
 ## Public Methods
 
+### Core Methods
+
 - `bool setUrl(String)` - Pass the URL to be handled to the class
-- `bool isMDNS(String)` - Return true/false based on whether URL is mDNS-based (*.local) or not
 - `String getUrl()` - Return a processed URI in the following format: `scheme:[//authority]path[?query][#fragment]`
 - `String getIPUrl()` - Return a processed URI with the host replaced by the IP address in the following format: `scheme:[//authority]path[?query][#fragment]` (useful for mDNS URLs)
 - `String getScheme()` - Get the scheme (currently only handles http and https)
@@ -52,6 +52,16 @@ If you are using mDNS in your projects, you may have discovered many microcontro
 - `String getQuery()` - Returns query (if present)
 - `String getFragment()` - Returns fragment (if present)
 
+### Utility Methods
+
+- `bool isMDNS()` - (deprecated)
+- `bool isMDNS(const char *hostName)` - Returns true if hostname is a valid mDNS name
+- `bool isValidIP(const char * hostName` - Returns true if hostName represents a valid IP address string
+- `int labelCount(const char * hostName)` - Integer of the number of labels in the hostname
+- `bool isANumber(const char * str)` - Returns true if string is a valid number
+- `bool isValidLabel(const char *label)` - Returns true if the string is a valid DNS label
+- `bool isValidHostName(const char *hostName)` - Return true if the hostname passed is a valid DNS, mDNS or IP hostname
+
 ## Progress:
 
 - [X] Convert percent-encoded triplets to uppercase
@@ -61,6 +71,7 @@ If you are using mDNS in your projects, you may have discovered many microcontro
 - [X] Convert an empty path to a "/" path
 - [X] Remove the default port
 - [X] ~~Add a trailing "/" to a non-empty path (may remove this)~~ (removed this after some thought)
+- [X] Add validity check functions (not yet part of the initialization)
 
 ## Installation
 

--- a/examples/Basic/Basic.ino
+++ b/examples/Basic/Basic.ino
@@ -31,45 +31,41 @@
 #include <LCBUrl.h>
 #include <Arduino.h>
 
+// LCBUrl does not require ArduinoLog.  It is used to
+// facilitate the examples.
+#include <ArduinoLog.h>
+#define LOG_LEVEL LOG_LEVEL_VERBOSE
+
 void setup() {
     Serial.begin(BAUD);
-    delay(1000);
-    Serial.println(F("Starting test run of LCBUrl:"));
+    Serial.println();
+    Serial.flush();
+    Log.begin(LOG_LEVEL, &Serial, true);
+    Log.notice(F("Starting test run of LCBUrl." CR CR));
 
     String myUrl = "http://%7EFoo:%7Ep@$$wOrd@Servername.local:8000/%7EthIs/is/A/./Path/test.php?foo=bar#frag";
     LCBUrl url;
 
     if (!url.setUrl(myUrl)) {
-        Serial.println(F("Failure in setUrl();"));
+        Log.fatal(F("Failure in setUrl();" CR));
     } else {
-        Serial.println(F("Return from setUrl():"));
-        Serial.print(F("\tgetUrl(); = "));
-        Serial.println(url.getUrl().c_str());
-        Serial.print(F("\tgetScheme(); = "));
-        Serial.println(url.getScheme().c_str());
-        Serial.print(F("\tgetUserInfo(); = "));
-        Serial.println(url.getUserInfo().c_str());
-        Serial.print(F("\tgetUserName(); = "));
-        Serial.println(url.getUserName().c_str());
-        Serial.print(F("\tgetPassword(); = "));
-        Serial.println(url.getPassword().c_str());
-        Serial.print(F("\tgetHost(); = "));
-        Serial.println(url.getHost().c_str());
-        Serial.print(F("\tgetPort(); = "));
-        Serial.println(url.getPort());
-        Serial.print(F("\tgetAuthority(); = "));
-        Serial.println(url.getAuthority().c_str());
-        Serial.print(F("\tgetPath(); = "));
-        Serial.println(url.getPath().c_str());
-        Serial.print(F("\tgetAfterPath(); = "));
-        Serial.println(url.getAfterPath().c_str());
-        Serial.print(F("\tgetQuery(); = "));
-        Serial.println(url.getQuery().c_str());
-        Serial.print(F("\tgetFragment(); = "));
-        Serial.println(url.getFragment().c_str());
+        Log.notice(F("Return from setUrl():" CR));
+
+        Log.notice(F("\tgetUrl(); = %s" CR), url.getUrl().c_str());
+        Log.notice(F("\tgetScheme(); = %s" CR), url.getScheme().c_str());
+        Log.notice(F("\tgetUserInfo(); = %s" CR), url.getUserInfo().c_str());
+        Log.notice(F("\tgetUserName(); = %s" CR), url.getUserName().c_str());
+        Log.notice(F("\tgetPassword(); = %s" CR), url.getPassword().c_str());
+        Log.notice(F("\tgetHost(); = %s" CR), url.getHost().c_str());
+        Log.notice(F("\tgetPort(); = %l" CR), url.getPort());
+        Log.notice(F("\tgetAuthority(); = %s" CR), url.getAuthority().c_str());
+        Log.notice(F("\tgetPath(); = %s" CR), url.getPath().c_str());
+        Log.notice(F("\tgetAfterPath(); = %s" CR), url.getAfterPath().c_str());
+        Log.notice(F("\tgetQuery(); = %s" CR), url.getQuery().c_str());
+        Log.notice(F("\tgetFragment(); = %s" CR CR), url.getFragment().c_str());
     }
 
-    Serial.println(F("LCBUrl test run complete."));
+    Log.notice(F("LCBUrl test run complete." CR));
 }
 
 void loop() {

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,6 +31,7 @@ build_flags =
     ; -DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_HIGHER_BANDWIDTH 		; v2 IPv6 Higher Bandwidth
     ; -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH 			; v1.4 Higher Bandwidth
 lib_deps = 
+    ArduinoLog
 extra_scripts = 
 build_type = debug
 

--- a/src/LCBUrl.h
+++ b/src/LCBUrl.h
@@ -40,8 +40,11 @@
 #include <ESPmDNS.h>
 #endif
 
+#include <stdio.h>
 #include <string.h>
 #include <Arduino.h>
+
+#include <ArduinoLog.h> // DEBUG
 
 // Library interface description
 class LCBUrl
@@ -51,7 +54,6 @@ public:
     LCBUrl(const String &newUrl = "");
     ~LCBUrl(){};
     bool setUrl(const String &newUrl);
-    bool isMDNS();
     String getUrl();
     String getIPUrl();
     String getScheme();
@@ -67,6 +69,15 @@ public:
     String getAfterPath();
     String getQuery();
     String getFragment();
+
+    // Utility functions
+    bool isMDNS() __attribute__ ((deprecated));
+    bool isMDNS(const char *hostName);
+    bool isValidIP(const char * hostName);
+    int labelCount(const char * hostName);
+    bool isANumber(const char * str);
+    bool isValidLabel(const char *label);
+    bool isValidHostName(const char *hostName);
 
     // Library-accessible "private" interface
 private:


### PR DESCRIPTION
Closes #18.  Adds new utility methods:

- `bool isMDNS()` - (deprecated)
- `bool isMDNS(const char *hostName)` - Returns true if hostname is a valid mDNS name
- `bool isValidIP(const char * hostName` - Returns true if hostName represents a valid IP address string
- `int labelCount(const char * hostName)` - Integer of the number of labels in the hostname
- `bool isANumber(const char * str)` - Returns true if string is a valid number
- `bool isValidLabel(const char *label)` - Returns true if the string is a valid DNS label
- `bool isValidHostName(const char *hostName)` - Return true if the hostname passed is a valid DNS, mDNS or IP hostname