### PR TITLE
Reduce library size

### DIFF
--- a/src/LCBUrl.cpp
+++ b/src/LCBUrl.cpp
@@ -64,64 +64,46 @@ bool LCBUrl::setUrl(const String &newUrl)
 
 String LCBUrl::getUrl() // Returned parsed/normalized URL
 {
-    if (url.isEmpty())
-    {
-        url = "";
-        url.concat(getScheme());
-        url.concat(F("://"));
-        url.concat(getAuthority());
-        url.concat(F("/"));
-        if (!getPath().isEmpty())
-        {
-            url.concat(getPath());
-        }
-        if (!getQuery().isEmpty())
-        {
-            url.concat(F("?"));
-            url.concat(getQuery());
-        }
-        if (getFragment() != "")
-        {
-            url.concat(F("#"));
-            url.concat(getFragment());
-        }
-        if ((getScheme() == "") || (getHost() == ""))
-        {
-            return url;
-        }
-    }
-    return url;
+    return getUrl(false, url);
 }
 
 String LCBUrl::getIPUrl() // Return cleaned URL with IP instead of FQDN
 {
-    if (ipurl.isEmpty())
+    return getUrl(true, ipurl);
+}
+
+String LCBUrl::getUrl(bool ipaddr, String &url_string)
+{
+    if (url_string.isEmpty())
     {
-        ipurl = "";
-        ipurl.concat(getScheme());
-        ipurl.concat(F("://"));
-        ipurl.concat(getIPAuthority());
-        ipurl.concat(F("/"));
+        url_string = "";
+        url_string.concat(getScheme());
+        url_string.concat(F("://"));
+        if (ipaddr)
+            url_string.concat(getIPAuthority());
+        else
+            url_string.concat(getAuthority());
+        url_string.concat(F("/"));
         if (!getPath().isEmpty())
         {
-            ipurl.concat(getPath());
+            url_string.concat(getPath());
         }
         if (!getQuery().isEmpty())
         {
-            ipurl.concat(F("?"));
-            ipurl.concat(getQuery());
+            url_string.concat(F("?"));
+            url_string.concat(getQuery());
         }
         if (getFragment() != "")
         {
-            ipurl.concat(F("#"));
-            ipurl.concat(getFragment());
+            url_string.concat(F("#"));
+            url_string.concat(getFragment());
         }
         if ((getScheme() == "") || (getHost() == ""))
         {
-            return ipurl;
+            return url_string;
         }
     }
-    return ipurl;
+    return url_string;
 }
 
 String LCBUrl::getScheme() // Returns URL scheme

--- a/src/LCBUrl.cpp
+++ b/src/LCBUrl.cpp
@@ -253,78 +253,61 @@ unsigned int LCBUrl::getPort() // Port will be any integer between : and / in au
     return port;
 }
 
-String LCBUrl::getAuthority() // Return username:password@fqdn:port
+String LCBUrl::getAuthority() // Returns {username (optional)}:{password (optional)}@{fqdn}
 {
-    if (authority.isEmpty())
-    {
-        authority = "";
-        if (!getUserName().isEmpty())
-        {
-            authority = getUserName();
-        }
-        if (!getPassword().isEmpty())
-        {
-            authority.concat(F(":"));
-            authority.concat(getPassword());
-        }
-        if (!authority.isEmpty())
-        {
-            authority.concat(F("@"));
-        }
-        authority.concat(getHost());
-        if (getPort() > 0)
-        {
-            if (
-                ((getScheme() == F("http")) && (port != 80)) ||
-                ((getScheme() == F("https")) && (port != 443)))
-            {
-                authority.concat(F(":"));
-                authority.concat(String(getPort()));
-            }
-        }
-    }
-    return authority;
+    return getAuthority(false, authority);
 }
 
-String LCBUrl::getIPAuthority() // Returns {username (optional)}:{password (optional)}@{fqdn}
+String LCBUrl::getIPAuthority() // Returns {username (optional)}:{password (optional)}@{ip_address}
 {
-    if (ipauthority.isEmpty())
+    return getAuthority(true, ipauthority);
+}
+
+String LCBUrl::getAuthority(bool ipaddr, String &authority_string)
+{
+    if (authority_string.isEmpty())
     {
+        authority_string = "";
         if (!getUserName().isEmpty())
         {
-            ipauthority = getUserName();
+            authority_string = getUserName();
         }
         if (!getPassword().isEmpty())
         {
-            ipauthority.concat(F(":"));
-            ipauthority.concat(getPassword());
+            authority_string.concat(F(":"));
+            authority_string.concat(getPassword());
         }
-        if (!ipauthority.isEmpty())
+        if (!authority_string.isEmpty())
         {
-            ipauthority.concat(F("@"));
+            authority_string.concat(F("@"));
         }
-        ipaddress = getIP(getHost());
+        if (ipaddr) {
+            ipaddress = getIP(getHost());
 
-        if (ipaddress == (IPAddress)IPADDR_NONE || ipaddress.toString().equalsIgnoreCase("(IP unset)"))
-        {
-            ipauthority.concat("255.255.255.255");
+            if (ipaddress == (IPAddress)IPADDR_NONE || ipaddress.toString().equalsIgnoreCase("(IP unset)"))
+            {
+                authority_string.concat("255.255.255.255");
+            }
+            else
+            {
+                authority_string.concat(ipaddress.toString());
+            }
+        } else {
+            authority.concat(getHost());
         }
-        else
-        {
-            ipauthority.concat(ipaddress.toString());
-        }
+
         if (getPort() > 0)
         {
             if (
                 ((getScheme() == F("http")) && (port != 80)) ||
                 ((getScheme() == F("https")) && (port != 443)))
             {
-                ipauthority.concat(F(":"));
-                ipauthority.concat(String(getPort()));
+                authority_string.concat(F(":"));
+                authority_string.concat(String(getPort()));
             }
         }
     }
-    return ipauthority;
+    return authority_string;
 }
 
 String LCBUrl::getPath() // Get all after host and port, before query and frag

--- a/src/LCBUrl.h
+++ b/src/LCBUrl.h
@@ -100,6 +100,7 @@ private:
     String getAfterPathNoFile();
     void initRegisters();
     String rawurl = "";
+    String getUrl(bool ipaddr, String &url_string);
     String url = "";
     String ipurl = "";
     String workingurl = "";

--- a/src/LCBUrl.h
+++ b/src/LCBUrl.h
@@ -113,6 +113,7 @@ private:
     String host = "";
     IPAddress ipaddress = INADDR_NONE;
     unsigned int port = 0;
+    String getAuthority(bool ipaddr, String &authority_string);
     String authority = "";
     String ipauthority = "";
     String pathsegment = "";


### PR DESCRIPTION
This PR combines getAuthority and getIPAuthority as well as getUrl and getIPUrl together into a single, master function in order to save space. Overall, this shrinks the compiled library size by ~1.4kb (about 10%) as used in Keg Cop. 