### PR TITLE
Arduino v3.x support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -83,8 +83,8 @@ monitor_filters =
 [env:heltec_wifi_kit_32_arduinov3]
 platform = https://github.com/platformio/platform-espressif32.git
 platform_packages =
-	platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.0-alpha3
-	platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/esp32-arduino-libs.git#idf-release/v5.1
+    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.7
+    platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.1/esp32-arduino-libs-idf-release_v5.1-632e0c2a.zip
 board = heltec_wifi_kit_32
 framework = ${common_env_data.framework}
 upload_speed = ${common_env_data.upload_speed}

--- a/platformio.ini
+++ b/platformio.ini
@@ -76,3 +76,27 @@ build_type = ${common_env_data.build_type}
 monitor_filters =
     ${common_env_data.monitor_filters}
     esp32_exception_decoder
+
+
+
+
+[env:heltec_wifi_kit_32_arduinov3]
+platform = https://github.com/platformio/platform-espressif32.git
+platform_packages =
+	platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.0-alpha3
+	platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/esp32-arduino-libs.git#idf-release/v5.1
+board = heltec_wifi_kit_32
+framework = ${common_env_data.framework}
+upload_speed = ${common_env_data.upload_speed}
+monitor_speed = ${common_env_data.monitor_speed}
+build_unflags = ${common_env_data.build_unflags}
+build_flags =
+    -DBAUD=${env:heltec_wifi_kit_32.monitor_speed}
+    ${common_env_data.build_flags}
+extra_scripts = ${common_env_data.extra_scripts}
+lib_deps = ${common_env_data.lib_deps}
+build_type = ${common_env_data.build_type}
+monitor_filters =
+    ${common_env_data.monitor_filters}
+    esp32_exception_decoder
+

--- a/src/LCBUrl.cpp
+++ b/src/LCBUrl.cpp
@@ -728,7 +728,8 @@ IPAddress LCBUrl::getIP(const char *fqdn) // Return IP address of FQDN (helpful 
     { // Host is an mDNS name
 #ifdef LCBURL_MDNS
 #ifdef ESP8266
-        int result = WiFi.hostByName(fqdn, &returnIP); // TODO: This is broken
+
+        int result = WiFi.hostByName(fqdn, returnIP); // TODO: This may be broken
 
         if (result == 1)
         {

--- a/src/LCBUrl.cpp
+++ b/src/LCBUrl.cpp
@@ -31,6 +31,31 @@
 
 #include "LCBUrl.h"
 
+
+// The following defines are in the lwip headers. In Arduino 2.x these headers are included by one
+// of the other upstream libraries -- now they are not. This enables us to use these defines without
+// creating another dependency. These are taken directly from:
+// https://github.com/espressif/esp-lwip/blob/master/src/include/lwip/ip4_addr.h
+#ifndef IPADDR_NONE
+/** 255.255.255.255 */
+#define IPADDR_NONE         ((uint32_t)0xffffffffUL)
+#endif
+
+#ifndef IPADDR_LOOPBACK
+/** 127.0.0.1 */
+#define IPADDR_LOOPBACK     ((uint32_t)0x7f000001UL)
+#endif
+
+#ifndef IPADDR_ANY
+/** 0.0.0.0 */
+#define IPADDR_ANY          ((uint32_t)0x00000000UL)
+#endif
+
+#ifndef IPADDR_BROADCAST
+/** 255.255.255.255 */
+#define IPADDR_BROADCAST    ((uint32_t)0xffffffffUL)
+#endif
+
 // Constructor/Destructor ////////////////////////////////////////////////
 // Handle the creation, setup, and destruction of instances
 


### PR DESCRIPTION
One of the changes coming with Arduino 3.x is that the lwip headers are no longer included by one of the upstream dependencies, resulting in there not being defines for things like IPADDR_NONE and IPADDR_LOOPBACK. This conditionally adds those defines.

An alternative implementation would be to do `#include <ip4_addr.h>` in LCBUrl.cpp where I have included the conditional defines.